### PR TITLE
Pass conversation history to coach and handle acknowledgments motivat…

### DIFF
--- a/nudge-backend/routes/coach.js
+++ b/nudge-backend/routes/coach.js
@@ -13,16 +13,21 @@ const router = express.Router();
  * so the most *relevant* entries (not just most recent) inform the answer.
  */
 router.post('/', async (req, res) => {
-  const { userId, question } = req.body;
+  const { userId, question, history } = req.body;
 
   if (!userId || !question?.trim()) {
     return res.status(400).json({ error: 'userId and question are required' });
   }
 
+  // Normalise history: array of {role, content} pairs, capped at last 10 turns
+  const conversationHistory = Array.isArray(history)
+    ? history.slice(-10).filter(m => m.role && m.content)
+    : [];
+
   try {
     // Semantic search: use the question itself as the query to surface relevant entries
     const entries = await searchEntries(userId, 20, question.trim());
-    const answer = await generateCoachAnswer(entries, question.trim());
+    const answer = await generateCoachAnswer(entries, question.trim(), conversationHistory);
     res.json({ answer });
   } catch (err) {
     console.error('coach error:', err.message);

--- a/nudge-backend/services/groq.js
+++ b/nudge-backend/services/groq.js
@@ -26,7 +26,8 @@ Rules:
 - If you spot a real pattern (specific days, activity types, streaks, gaps), name it explicitly
 - If there's not enough history to answer well, say so honestly and tell them what to log
 - Never be preachy or lecture about health — focus on patterns, observations, and encouragement
-- Never use filler phrases like "great job" or "keep it up"`;
+- Never use filler phrases like "great job" or "keep it up"
+- IMPORTANT: If the person sends a short acknowledgment like "thanks", "ok", "alright", "got it", "cool", or similar closing remarks — do NOT repeat or summarise what was already discussed. Instead, respond with a single genuinely motivating sentence that highlights one concrete positive thing you can see in their data (a streak, a favourite activity, a recent win). Keep it fresh, specific, and forward-looking.`;
 
 /**
  * Parse a date from an entry string like "On Wed Mar 12 2025, the user..."
@@ -84,21 +85,25 @@ export async function generateNudge(entries, userName = 'friend') {
  * Answer a free-form question from the user using their movement history as context.
  * @param {string[]} entries  Relevant entries from Supermemory (semantic search results)
  * @param {string}   question The user's question
+ * @param {Array<{role: string, content: string}>} history  Recent conversation turns (oldest first)
  * @returns {string}          The coach's answer
  */
-export async function generateCoachAnswer(entries, question) {
+export async function generateCoachAnswer(entries, question, history = []) {
   const context = entries.length > 0
     ? entries.map((e, i) => `Entry ${i + 1}: ${e}`).join('\n')
     : 'No movement history stored yet.';
 
-  const userPrompt = `Here is this person's relevant movement history (most relevant entries first):\n\n${context}\n\nTheir question: ${question}`;
+  const systemWithContext = `${COACH_SYSTEM_PROMPT}\n\nMovement history context (most relevant entries first):\n${context}`;
+
+  const messages = [
+    { role: 'system', content: systemWithContext },
+    ...history,
+    { role: 'user', content: question },
+  ];
 
   const completion = await client().chat.completions.create({
     model: 'llama-3.1-8b-instant',
-    messages: [
-      { role: 'system', content: COACH_SYSTEM_PROMPT },
-      { role: 'user', content: userPrompt },
-    ],
+    messages,
     max_tokens: 200,
     temperature: 0.75,
   });

--- a/nudge/Services/BackendService.swift
+++ b/nudge/Services/BackendService.swift
@@ -64,14 +64,15 @@ enum BackendService {
 
     // MARK: - Ask your coach (free-form Q&A against Supermemory history)
 
-    static func askCoach(question: String) async throws -> String {
+    static func askCoach(question: String, history: [[String: String]] = []) async throws -> String {
         guard let url = URL(string: "\(baseURL)/api/coach") else {
             throw URLError(.badURL)
         }
 
         let body: [String: Any] = [
             "userId": UserService.userId,
-            "question": question
+            "question": question,
+            "history": history
         ]
 
         var request = URLRequest(url: url)

--- a/nudge/Views/CoachView.swift
+++ b/nudge/Views/CoachView.swift
@@ -295,9 +295,18 @@ struct CoachView: View {
         isLoading = true
         errorMessage = nil
 
+        // Build conversation history from the last 5 exchanges (10 turns)
+        let recentMessages = messages.suffix(5)
+        let history: [[String: String]] = recentMessages.flatMap { msg in
+            [
+                ["role": "user", "content": msg.question],
+                ["role": "assistant", "content": msg.answer]
+            ]
+        }
+
         Task {
             do {
-                let answer = try await BackendService.askCoach(question: question)
+                let answer = try await BackendService.askCoach(question: question, history: history)
                 await MainActor.run {
                     let msg = CoachMessage(question: question, answer: answer)
                     withAnimation { messages.append(msg) }


### PR DESCRIPTION
…ionally

- Send last 5 message exchanges as conversation history with each coach request
- Backend route now accepts and forwards history to the LLM
- generateCoachAnswer includes history turns in the messages array so the model has full context
- System prompt instructs coach to respond to short acknowledgments (thanks, ok, alright) with a single fresh motivational sentence based on a concrete positive from their data — not a repetition of what was already said

https://claude.ai/code/session_01KYUVoCLaeeYinWFePDxKLk